### PR TITLE
Fix validation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Now that you have deployed in a Container Apps Environment, you can validate its
         "weight": 10
       },
       "pickupLocation": "mypickup",
-      "pickupTime": "'$(date -u +%FT%T.%3NZ)'"
+      "pickupTime": "'$(date -u +%FT%TZ)'"
     }'
    ```
 


### PR DESCRIPTION
Identified an issue with the embedded date command in the validation instructions. It was working as expected on Linux, but not on MacOS.

- Update validation command to use a simpler date command that produces expected results on MacOS and Linux (Tested on Ubuntu 20, MacOS 12.2)